### PR TITLE
menu image

### DIFF
--- a/foodie/models/menu.py
+++ b/foodie/models/menu.py
@@ -12,7 +12,7 @@ class Menu(models.Model):
     rating = models.FloatField(default=0.0) #might not need this field
     num_ratings = models.IntegerField(default=0) #might not need this field
     times_ordered = models.IntegerField(default=0)
-    image_url = models.URLField(default="")
+    image_url = models.CharField(max_length=50, null=True, blank=False)
     on_menu = models.BooleanField(default=True)#Instead of deleting we just flip on_menu to false so it doesn't break relationships
     created_by = models.ForeignKey(
             Employee,

--- a/foodie/templates/menu.html
+++ b/foodie/templates/menu.html
@@ -29,7 +29,7 @@
         {% for item in row %}
         <div class="col-md-3">
             <div class="thumbnail">
-                <img src="{{ item.image_url }}" />
+                <img src="{% static item.image_url %}" />
                 <div class="caption">
                     <h3>{{ item.name }}</h3>
                     <p>${{ item.price }}</p>


### PR DESCRIPTION
I make a minor change to the menu template and the menu model to take  the static  image from our folder img/portfolio/img.
![image](https://cloud.githubusercontent.com/assets/18431872/25818536/e4bbe316-33f8-11e7-859d-a46d69f14ee3.png)

So no more putting url on the local admin page, we can add img from what we have locally in our repo,
![image](https://cloud.githubusercontent.com/assets/18431872/25818594/1050026e-33f9-11e7-8ec5-10394d66ff11.png)
